### PR TITLE
Use the dev plan for CI

### DIFF
--- a/templates/postgresql-apb.yaml
+++ b/templates/postgresql-apb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: postgresql
 spec:
   clusterServiceClassExternalName: dh-postgresql-apb
-  clusterServicePlanExternalName: prod
+  clusterServicePlanExternalName: dev
   parameters:
     postgresql_database: "admin"
     postgresql_password: "admin"


### PR DESCRIPTION
The prod plan uses a pv for storage. It's not necessary to use this in CI since we don't require persistent data.